### PR TITLE
Tenant Handling

### DIFF
--- a/gaetk/handler.py
+++ b/gaetk/handler.py
@@ -66,8 +66,10 @@ class Credential(db.Expando):
         if not uid:
             handmade_key = db.Key.from_path('Credential', 1)
             uid = "u%s" % (db.allocate_ids(handmade_key, 1)[0])
-        instance = cls.get_or_insert(key_name=uid, uid=uid, secret=secret, tenant=tenant,
-                                     user=user, text=text, email=email)
+        instance = cls.get_or_insert(key_name=uid, uid=uid, secret=secret, user=user, text=text, email=email)
+        if tenant:
+            instance.tenant = tenant
+            instance.put()
         return instance
 
     def __repr__(self):

--- a/gaetk/login.py
+++ b/gaetk/login.py
@@ -72,7 +72,7 @@ class OpenIdLoginHandler(BasicHandler):
             credential = Credential.get_by_key_name(username)
             if not credential or not credential.uid == username:
                 # So far we have no Credential entity for that user, create one
-                credential = create_credential_from_federated_login(self, user, apps_domain)
+                credential = self.create_credential_from_federated_login(user, apps_domain)
             session['uid'] = credential.uid
             self.redirect(continue_url)
             return


### PR DESCRIPTION
Tenant Feld wird mit "_unknown" belegt, falls kein Wert in der Credential.create() Methode übergeben wird.
